### PR TITLE
Made $formats protected

### DIFF
--- a/src/Negotiation/FormatNegotiator.php
+++ b/src/Negotiation/FormatNegotiator.php
@@ -8,7 +8,7 @@ namespace Negotiation;
 class FormatNegotiator extends Negotiator
 {
     // https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Request.php
-    private $formats = array(
+    protected $formats = array(
         'html' => array('text/html', 'application/xhtml+xml'),
         'txt'  => array('text/plain'),
         'js'   => array('application/javascript', 'application/x-javascript', 'text/javascript'),


### PR DESCRIPTION
One can now extend the class and overwrite all built-in formats with a app-specific smaller/restricted set of possible mime types.

This is works for my use case, when I only want to accept json and xml, but priorities should be handled by the FormatNegotiator.
