### PR TITLE
prevent partial matches

### DIFF
--- a/src/Negotiation/FormatNegotiator.php
+++ b/src/Negotiation/FormatNegotiator.php
@@ -37,7 +37,7 @@ class FormatNegotiator extends Negotiator
                     return $accept;
                 }
 
-                $regex = '#^' . preg_quote($mimeType) . '#';
+                $regex = '#^' . preg_quote($mimeType) . '$#';
 
                 foreach ($priorities as $priority) {
                     if (self::CATCH_ALL_VALUE !== $priority && 1 === preg_match($regex, $priority)) {


### PR DESCRIPTION
see https://github.com/willdurand/Negotiation/commit/29ed0cab65ce352c6ff1cde0b053c91c8a6b2bb6#commitcomment-4104094

f.e. this also makes it impossible to register a new format `jsonp` as `application/javascript+jsonp` because it will already be matched to `js` (semi related to this is the issue that currently there is no way to force the new format to be placed in a specific location in the existing formats array).
