### PR TITLE
Added clarifying test

### DIFF
--- a/tests/Negotiation/Tests/FormatNegotiatorTest.php
+++ b/tests/Negotiation/Tests/FormatNegotiatorTest.php
@@ -264,6 +264,8 @@ class FormatNegotiatorTest extends TestCase
             array('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', array('html', 'json', '*/*'), 'html'),
             array('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', array('rss', '*/*'), 'html'),
             array('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', array('xml'), 'xml'),
+            // This shows clearly that the acceptheader is leading over server priorities
+            array('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', array('xml', 'html'), 'html'),
             array('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', array('json', 'xml'), 'xml'),
             array('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', array('json'), 'json'),
             array('text/html,application/xhtml+xml,application/xml;q=0.9,*/*', array('json'), 'json'),


### PR DESCRIPTION
Added clarifying test to show that client accept header comes before server priorities. The array is called $priorities, which made me think that, when equal scored, the $priorities array would be considered for the final result. This, however, is not the case. That's what this test shows.
