### PR TITLE
Made priority matching return item from priorities in favor of headers from user agent

### DIFF
--- a/src/Negotiation/Negotiator.php
+++ b/src/Negotiation/Negotiator.php
@@ -15,33 +15,21 @@ class Negotiator implements NegotiatorInterface
     public function getBest($header, array $priorities = array())
     {
         $acceptHeaders = $this->parseHeader($header);
+        $best = reset($acceptHeaders);
 
         if (0 === count($acceptHeaders)) {
             return null;
         }
 
         if (0 !== count($priorities)) {
-            $priorities = $this->sanitize($priorities);
+            $value = $this->match($acceptHeaders, $priorities);
 
-            $wildcardAccept = null;
-            foreach ($acceptHeaders as $accept) {
-                if ($this->matchPriorities($accept, $priorities)) {
-                    return $accept;
-                }
-
-                if ('*' === $accept->getValue()) {
-                    $wildcardAccept = $accept;
-                }
-            }
-
-            if (null !== $wildcardAccept) {
-                $value = reset($priorities);
-
-                return new AcceptHeader($value, $wildcardAccept->getQuality(), $this->parseParameters($value));
+            if (!empty($value)) {
+                $best = new AcceptHeader($value, 1.0, $this->parseParameters($value));
             }
         }
 
-        return reset($acceptHeaders);
+        return $best;
     }
 
     /**
@@ -166,13 +154,30 @@ class Negotiator implements NegotiatorInterface
     }
 
     /**
-     * @param AcceptHeader $acceptHeader
-     * @param array        $priorities
+     * @param array[AcceptHeader] $acceptHeaders Sorted by quality
+     * @param array               $priorities    Configured priorities
      *
-     * @return boolean
+     * @return string|null Header string matched
      */
-    protected function matchPriorities(AcceptHeader $acceptHeader, array $priorities = array())
+    protected function match(array $acceptHeaders, array $priorities  = array())
     {
-        return in_array(strtolower($acceptHeader->getValue()), $priorities);
+        $sanitizedPriorities = $this->sanitize($priorities);
+
+        foreach ($acceptHeaders as $accept) {
+            $found = array_search(strtolower($accept->getValue()), $sanitizedPriorities);
+            if (false !== $found) {
+                return $priorities[$found];
+            }
+
+            if ('*' === $accept->getValue()) {
+                $wildcardAccept = $accept;
+            }
+        }
+
+        if (null !== $wildcardAccept) {
+            $value = reset($priorities);
+
+            return $value;
+        }
     }
 }

--- a/tests/Negotiation/Tests/LanguageNegotiatorTest.php
+++ b/tests/Negotiation/Tests/LanguageNegotiatorTest.php
@@ -71,7 +71,7 @@ class LanguageNegotiatorTest extends TestCase
         $acceptHeader = $this->negotiator->getBest($acceptLanguageHeader, $priorities);
 
         $this->assertInstanceOf('Negotiation\AcceptHeader', $acceptHeader);
-        $this->assertEquals('en', $acceptHeader->getValue());
+        $this->assertEquals('en-US', $acceptHeader->getValue());
     }
 
     public static function dataProviderForGetBest()

--- a/tests/Negotiation/Tests/NegotiatorTest.php
+++ b/tests/Negotiation/Tests/NegotiatorTest.php
@@ -39,7 +39,7 @@ class NegotiatorTest extends TestCase
         $acceptHeader = $this->negotiator->getBest('foo, bar, yo', array('YO'));
 
         $this->assertInstanceOf('Negotiation\AcceptHeader', $acceptHeader);
-        $this->assertEquals('yo', $acceptHeader->getValue());
+        $this->assertEquals('YO', $acceptHeader->getValue());
     }
 
     public function testGetBestWithQualities()
@@ -176,7 +176,7 @@ class NegotiatorTest extends TestCase
                     'iso-8859-1',
                     'shift-jis',
                 ),
-                'ISO-8859-1'
+                'iso-8859-1'
             ),
             array(
                 $pearCharsetHeader,
@@ -210,7 +210,7 @@ class NegotiatorTest extends TestCase
                     'iso-8859-1',
                     'shift-jis',
                 ),
-                'ISO-8859-1'
+                'iso-8859-1'
             ),
             array(
                 $pearCharsetHeader2,


### PR DESCRIPTION
This is a implementation proposal for issue #21.

That is, best header is based on priority value instead of header value.  

For instance, in case of language negotiation:

``` gherkin
Given an Accept-Language header "fr-FR, en"
When negotiated against the following priorities:
    | priorities | 
    | en_US      |
    | de_DE      |
Then the negotiated accept header has a value of "en_US"  
```

Before this PR, the resulting value would have been `en`.
