### PR TITLE
Add a failing test with IE8 Accept

### DIFF
--- a/tests/Negotiation/Tests/FormatNegotiatorTest.php
+++ b/tests/Negotiation/Tests/FormatNegotiatorTest.php
@@ -279,9 +279,7 @@ class FormatNegotiatorTest extends TestCase
             ),
             // IE8 Accept header
             array(
-                // @codingStandardsIgnoreStart
                 'image/jpeg, application/x-ms-application, image/gif, application/xaml+xml, image/pjpeg, application/x-ms-xbap, */*',
-                // @codingStandardsIgnoreEnd
                 array(
                     'text/html',
                     'application/xhtml+xml',


### PR DESCRIPTION
Related with: https://github.com/FriendsOfSymfony/FOSRestBundle/issues/682

```
Configuration read from /var/www/Negotiation/phpunit.xml.dist

............................F.................................... 65 / 98 ( 66%)
.................................

Time: 79 ms, Memory: 4.00Mb

There was 1 failure:

1) Negotiation\Tests\FormatNegotiatorTest::testGetBest with data set #24 ('image/jpeg, application/x-ms-application, image/gif, application/xaml+xml, image/pjpeg, application/x-ms-xbap, */*', array('text/html', 'application/xhtml+xml', '*/*'), 'text/html')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'text/html'
+'image/jpeg'

/var/www/Negotiation/tests/Negotiation/Tests/FormatNegotiatorTest.php:43

FAILURES!
Tests: 98, Assertions: 231, Failures: 1.
```
