### PR TITLE
add AcceptHeader::getMediaType()

### DIFF
--- a/src/Negotiation/AcceptHeader.php
+++ b/src/Negotiation/AcceptHeader.php
@@ -37,6 +37,14 @@ class AcceptHeader
     /**
      * @return string
      */
+    public function getMediaType()
+    {
+        return explode(';', $this->value, 1)[0];
+    }
+
+    /**
+     * @return string
+     */
     public function getValue()
     {
         return $this->value;

--- a/tests/Negotiation/Tests/AcceptHeaderTest.php
+++ b/tests/Negotiation/Tests/AcceptHeaderTest.php
@@ -14,7 +14,7 @@ class AcceptHeaderTest extends TestCase
 
     protected function setUp()
     {
-        $this->acceptHeader = new AcceptHeader('foo', 1.0, array(
+        $this->acceptHeader = new AcceptHeader('foo/bar', 1.0, array(
             'hello' => 'world',
         ));
     }
@@ -46,5 +46,11 @@ class AcceptHeaderTest extends TestCase
             array('*/*', true),
             array('application/json', false),
         );
+    }
+
+    public function testGetMediaType() {
+        $mt = $this->acceptHeader->getMediaType();
+
+        $this->assertEquals($mt, 'foo/bar');
     }
 }


### PR DESCRIPTION
Necessary to get the actual media type without the parameters appened.