### PR TITLE
add AcceptHeader::getMediaType()

### DIFF
--- a/src/Negotiation/AcceptHeader.php
+++ b/src/Negotiation/AcceptHeader.php
@@ -40,7 +40,8 @@ class AcceptHeader
     public function getMediaType()
     {
         $parts = explode(';', $this->value, 2);
-        return $parts[0];
+        $mediaType = trim($parts[0], ' ');
+        return $mediaType;
     }
 
     /**

--- a/src/Negotiation/AcceptHeader.php
+++ b/src/Negotiation/AcceptHeader.php
@@ -37,6 +37,15 @@ class AcceptHeader
     /**
      * @return string
      */
+    public function getMediaType()
+    {
+        $parts = explode(';', $this->value, 2);
+        return $parts[0];
+    }
+
+    /**
+     * @return string
+     */
     public function getValue()
     {
         return $this->value;

--- a/tests/Negotiation/Tests/AcceptHeaderTest.php
+++ b/tests/Negotiation/Tests/AcceptHeaderTest.php
@@ -47,4 +47,16 @@ class AcceptHeaderTest extends TestCase
             array('application/json', false),
         );
     }
+
+    public function testGetMediaType() {
+        # with param
+        $acceptHeader = new AcceptHeader('text/html;hello=world', 1.0, array( 'hello' => 'world',));
+        $mt = $acceptHeader->getMediaType();
+        $this->assertEquals($mt, 'text/html');
+
+        # without param
+        $acceptHeader = new AcceptHeader('application/pdf', 1.0, array());
+        $mt = $acceptHeader->getMediaType();
+        $this->assertEquals($mt, 'application/pdf');
+    }
 }

--- a/tests/Negotiation/Tests/AcceptHeaderTest.php
+++ b/tests/Negotiation/Tests/AcceptHeaderTest.php
@@ -3,9 +3,18 @@
 namespace Negotiation\Tests;
 
 use Negotiation\AcceptHeader;
+use Negotiation\Negotiator;
 
 class AcceptHeaderTest extends TestCase
 {
+
+    protected function call_private_method($class, $method, $object, $params) {
+        $method = new \ReflectionMethod($class, $method);
+
+        $method->setAccessible(TRUE);
+
+        return $method->invokeArgs($object, $params);
+    }
 
     /**
      * @var AcceptHeader
@@ -48,15 +57,45 @@ class AcceptHeaderTest extends TestCase
         );
     }
 
-    public function testGetMediaType() {
-        # with param
-        $acceptHeader = new AcceptHeader('text/html;hello=world', 1.0, array( 'hello' => 'world',));
-        $mt = $acceptHeader->getMediaType();
-        $this->assertEquals($mt, 'text/html');
+    /**
+     * @dataProvider dataProviderForTestGetMediaType
+     */
+    public function testGetMediaType($acceptHeader, $expectedType) {
 
-        # without param
-        $acceptHeader = new AcceptHeader('application/pdf', 1.0, array());
+        $negotiator = new Negotiator();
+        $parameters = $this->call_private_method('\Negotiation\Negotiator', 'parseParameters', $negotiator, array($acceptHeader)); 
+
+        $acceptHeader = new AcceptHeader($acceptHeader, 1.0, $parameters);
         $mt = $acceptHeader->getMediaType();
-        $this->assertEquals($mt, 'application/pdf');
+
+        $this->assertEquals($expectedType, $mt);
+
+    }
+
+    public static function dataProviderForTestGetMediaType()
+    {
+        return array(
+            array('text/html;hello=world', 'text/html'), # with param
+            array('application/pdf', 'application/pdf'), # without param
+            array('application/xhtml+xml;q=0.9', 'application/xhtml+xml'),
+            array('text/plain; q=0.5', 'text/plain'),
+            array('text/html;level=2;q=0.4', 'text/html'),
+            array('text/html ; level = 2   ; q = 0.4', 'text/html'),
+            array('text/*', 'text/*'),
+            array('text/* ;q=1 ;level=2', 'text/*'),
+            array('*/*', '*/*'),
+            array('*/* ; param=555', '*/*'),
+            array('TEXT/hTmL;leVel=2; Q=0.4', 'TEXT/hTmL'),
+
+            # language
+            array('da', 'da'),
+            array('en-gb;q=0.8', 'en-gb'),
+            array('en-GB;q=0.8', 'en-GB'),
+            array('es;q=0.7', 'es'),
+            array('fr ; q= 0.1', 'fr'),
+
+            array('', null),
+            array(null, null),
+        );
     }
 }


### PR DESCRIPTION
Necessary to get the actual media type without the parameters appened.