### PR TITLE
fix langage negotiation to choose generic if available when asking for specific

### DIFF
--- a/src/Negotiation/LanguageNegotiator.php
+++ b/src/Negotiation/LanguageNegotiator.php
@@ -51,6 +51,7 @@ class LanguageNegotiator extends Negotiator
     protected function match(array $acceptHeaders, array $priorities = array())
     {
         $wildcardAccept  = null;
+        $genericAccept   = null;
 
         $prioritiesSet   = array();
         $prioritiesSet[] = $priorities;
@@ -66,10 +67,21 @@ class LanguageNegotiator extends Negotiator
                     return $priorities[$found];
                 }
 
+                if (null === $genericAccept && false !== strpos($accept->getValue(), '-')) {
+                    $genericValue = explode('-', $accept->getValue());
+                    if ($genericValue && (false !== $found = array_search(strtolower($genericValue[0]), $sanitizedPriorities))) {
+                        $genericAccept = $priorities[$found];
+                    }
+                }
+
                 if ('*' === $accept->getValue()) {
                     $wildcardAccept = $accept;
                 }
             }
+        }
+
+        if ($genericAccept) {
+            return $genericAccept;
         }
 
         if (null !== $wildcardAccept) {

--- a/tests/Negotiation/Tests/LanguageNegotiatorTest.php
+++ b/tests/Negotiation/Tests/LanguageNegotiatorTest.php
@@ -78,6 +78,22 @@ class LanguageNegotiatorTest extends TestCase
         $this->assertEquals('en-US', $acceptHeader->getValue());
     }
 
+    /**
+     * Given a accept header containing specific languages (here 'en-US', 'fr-FR')
+     *  And priorities containing a generic version of that language
+     * Then the best language is mapped to the generic one here 'fr'
+     */
+    public function testSpecificLanguageAreMappedToGeneric()
+    {
+        $acceptLanguageHeader = 'fr-FR, en-US;q=0.8';
+        $priorities           = array('fr');
+
+        $acceptHeader = $this->negotiator->getBest($acceptLanguageHeader, $priorities);
+
+        $this->assertInstanceOf('Negotiation\AcceptHeader', $acceptHeader);
+        $this->assertEquals('fr', $acceptHeader->getValue());
+    }
+
     public function testGetBestWithWildcard()
     {
         $acceptLanguageHeader = 'en, *;q=0.9';


### PR DESCRIPTION
Hi,

We got the same issue has #26 

The pull request allow to match a generic language from priorities at last resort if header only provide specific and none match.

I added a unit test :)

@willdurand this is the flexible solution you ask for in #26 but maybe you change your mind ;)