### PR TITLE
AcceptLanguage: InvalidLanguage exception use fix

### DIFF
--- a/src/Negotiation/AcceptLanguage.php
+++ b/src/Negotiation/AcceptLanguage.php
@@ -2,6 +2,8 @@
 
 namespace Negotiation;
 
+use Negotiation\Exception\InvalidLanguage;
+
 final class AcceptLanguage extends BaseAccept implements AcceptHeader
 {
     private $basePart;


### PR DESCRIPTION
Currently there's a fatal error on line 26 because of this missing `use` statement.