### PR TITLE
Reduce try/catch to getBest method only.

### DIFF
--- a/tests/Negotiation/Tests/NegotiatorTest.php
+++ b/tests/Negotiation/Tests/NegotiatorTest.php
@@ -28,18 +28,22 @@ class NegotiatorTest extends TestCase
     {
         try {
             $acceptHeader = $this->negotiator->getBest($header, $priorities);
-
-            if ($acceptHeader === null) {
-                $this->assertNull($expected);
-            } else {
-                $this->assertInstanceOf('Negotiation\Accept', $acceptHeader);
-
-                $this->assertSame($expected[0], $acceptHeader->getType());
-                $this->assertSame($expected[1], $acceptHeader->getParameters());
-            }
         } catch (\Exception $e) {
             $this->assertEquals($expected, $e);
+
+            return;
         }
+
+        if ($acceptHeader === null) {
+            $this->assertNull($expected);
+
+            return;
+        }
+
+        $this->assertInstanceOf('Negotiation\Accept', $acceptHeader);
+
+        $this->assertSame($expected[0], $acceptHeader->getType());
+        $this->assertSame($expected[1], $acceptHeader->getParameters());
     }
 
     public static function dataProviderForTestGetBest()


### PR DESCRIPTION
PHPUnit uses Exceptions in its asserts functions. In case of assertion
failure in test, it is caught by the catch block and give a wrong message.

I bumped Negotiator revision, a previously passing test is now fail, but I figured out that the issue was in my Accept header. Anyway, I open this PR to fix an issue with `getBest()` test.

I first wanted to add this test in dataProviderForTestGetBest:
```php
            # json requested
            array('application/json, */*', array('text/html', 'application/json'), array('application/json', array())),
```
The issue is that there are no quality parameter for the catch all, which causes `getBest()` to return `text/html`. I was expecting `application/json` but the library still is compliant.