### PR TITLE
BC break? - Fix for issue #81 - silently skip invalid header values coming in from clients

### DIFF
--- a/tests/Negotiation/Tests/NegotiatorTest.php
+++ b/tests/Negotiation/Tests/NegotiatorTest.php
@@ -53,7 +53,9 @@ class NegotiatorTest extends TestCase
 
         return array(
             # exceptions
-            array('/qwer', array('f/g'), new InvalidMediaType()),
+            array('/qwer', array('f/g'), null),
+            array('/qwer,f/g', array('f/g'), array('f/g', array())),
+            array('foo/bar', array('/qwer'), new InvalidMediaType()),
             array('', array('foo/bar'), new InvalidArgument('The header string should not be empty.')),
             array('*/*', array(), new InvalidArgument('A set of server priorities should be given.')),
 


### PR DESCRIPTION
silently skip invalid header values coming in from a client

instead of throwing exceptions on invalid headers from clients, the new code silently skips these header values and continues to parse the header for a best match