### PR TITLE
Add $strict parameter to getBest()

### DIFF
--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -13,7 +13,7 @@ abstract class AbstractNegotiator
      *
      * @return AcceptHeader|null best matching type
      */
-    public function getBest($header, array $priorities)
+    public function getBest($header, array $priorities, $strict = false)
     {
         if (empty($priorities)) {
             throw new InvalidArgument('A set of server priorities should be given.');
@@ -33,7 +33,9 @@ abstract class AbstractNegotiator
             try {
                 $acceptedHeaders[] = $this->acceptFactory($h);
             } catch (Exception\Exception $e) {
-                // silently skip in case of invalid headers coming in from a client
+                if ($strict) {
+                    throw $e;
+                }
             }
         }
         $acceptedPriorities = array();

--- a/tests/Negotiation/Tests/NegotiatorTest.php
+++ b/tests/Negotiation/Tests/NegotiatorTest.php
@@ -104,6 +104,17 @@ class NegotiatorTest extends TestCase
         $this->assertEquals('text/plain', $accept->getType());
     }
 
+   /**
+    * @expectedException Negotiation\Exception\InvalidMediaType
+    */
+    public function testGetBestInvalidMediaType()
+    {
+        $header = 'sdlfkj20ff; wdf';
+        $priorities = array('foo/qwer');
+
+        $this->negotiator->getBest($header, $priorities, true);
+    }
+
     /**
      * @dataProvider dataProviderForTestParseHeader
      */


### PR DESCRIPTION
Add `$strict` parameter to `getBest()` to enable exceptions for invalid media types. Defaults to `false` so is backwards compatible.