### PR TITLE
Implement getOrderedElements()

### DIFF
--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -53,6 +53,35 @@ abstract class AbstractNegotiator
     }
 
     /**
+     * @param string $header  A string containing an `Accept|Accept-*` header.
+     *
+     * @return [AcceptHeader] An ordered list of accept header elements
+     */
+    public function getOrderedElements($header)
+    {
+        if (!$header) {
+            throw new InvalidArgument('The header string should not be empty.');
+        }
+
+        $elements = array();
+        foreach ($this->parseHeader($header) as $h) {
+            try {
+                $elements[] = $this->acceptFactory($h);
+            } catch (Exception\Exception $e) {
+                // silently skip in case of invalid headers coming in from a client
+            }
+        }
+
+        // sort based on quality
+        usort($elements, function (BaseAccept $a, BaseAccept $b) {
+             return $a->getQuality() < $b->getQuality();
+        });
+
+        return $elements;
+    }
+
+
+    /**
      * @param string $header accept header part or server priority
      *
      * @return AcceptHeader Parsed header object

--- a/tests/Negotiation/Tests/NegotiatorTest.php
+++ b/tests/Negotiation/Tests/NegotiatorTest.php
@@ -97,6 +97,53 @@ class NegotiatorTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider dataProviderForTestGetOrderedElements
+     */
+    public function testGetOrderedElements($header, $expected)
+    {
+        try {
+            $elements = $this->negotiator->getOrderedElements($header);
+        } catch (\Exception $e) {
+            $this->assertEquals($expected, $e);
+            return;
+        }
+
+        if (empty($elements)) {
+            $this->assertNull($expected);
+            return;
+        }
+
+        $this->assertInstanceOf('Negotiation\Accept', $elements[0]);
+
+        foreach ($expected as $key => $item) {
+            $this->assertSame($item, $elements[$key]->getValue());
+        }
+    }
+
+    public static function dataProviderForTestGetOrderedElements()
+    {
+        return array(
+            // error cases
+            array('', new InvalidArgument('The header string should not be empty.')),
+            array('/qwer', null),
+
+            // first one wins as no quality modifiers
+            array('text/html, text/xml', array('text/html', 'text/xml')),
+            
+            // ordered by quality modifier
+            array(
+                'text/html;q=0.3, text/html;q=0.7',
+                array('text/html;q=0.7', 'text/html;q=0.3')
+            ),
+            // ordered by quality modifier - the one with no modifier wins, level not taken into account
+            array(
+                'text/*;q=0.3, text/html;q=0.7, text/html;level=1, text/html;level=2;q=0.4, */*;q=0.5',
+                array('text/html;level=1', 'text/html;q=0.7', '*/*;q=0.5', 'text/html;level=2;q=0.4', 'text/*;q=0.3')
+            ),
+        );
+    }
+
     public function testGetBestRespectsQualityOfSource()
     {
         $accept = $this->negotiator->getBest('text/html,text/*;q=0.7', array('text/html;q=0.5', 'text/plain;q=0.9'));


### PR DESCRIPTION
This method retrieves the elements of the given Accept/Accept-* header as an array ordered with the most preferred first.

Fixes #75