### PR TITLE
Handle wildcard "+" segments

### DIFF
--- a/src/Negotiation/Negotiator.php
+++ b/src/Negotiation/Negotiator.php
@@ -21,23 +21,62 @@ class Negotiator extends AbstractNegotiator
             return null;
         }
 
-        $ab = $accept->getBasePart();
-        $pb = $priority->getBasePart();
+        $acceptBase = $accept->getBasePart();
+        $priorityBase = $priority->getBasePart();
 
-        $as = $accept->getSubPart();
-        $ps = $priority->getSubPart();
+        $acceptSub = $accept->getSubPart();
+        $prioritySub = $priority->getSubPart();
 
         $intersection = array_intersect_assoc($accept->getParameters(), $priority->getParameters());
 
-        $baseEqual = !strcasecmp($ab, $pb);
-        $subEqual  = !strcasecmp($as, $ps);
+        $baseEqual = !strcasecmp($acceptBase, $priorityBase);
+        $subEqual  = !strcasecmp($acceptSub, $prioritySub);
 
-        if (($ab === '*' || $baseEqual) && ($as === '*' || $subEqual) && count($intersection) === count($accept->getParameters())) {
+        if (($acceptBase === '*' || $baseEqual)
+            && ($acceptSub === '*' || $subEqual)
+            && count($intersection) === count($accept->getParameters())
+        ) {
             $score = 100 * $baseEqual + 10 * $subEqual + count($intersection);
 
             return new Match($accept->getQuality() * $priority->getQuality(), $score, $index);
         }
 
+        if (!strstr($acceptSub, '+') || !strstr($prioritySub, '+')) {
+            return null;
+        }
+
+        // Handle "+" segment wildcards
+        list($acceptSub, $acceptPlus) = $this->splitSubPart($acceptSub);
+        list($prioritySub, $priorityPlus) = $this->splitSubPart($prioritySub);
+
+        $subEqual  = !strcasecmp($acceptSub, $prioritySub);
+        $plusEqual = !strcasecmp($acceptPlus, $priorityPlus);
+
+        if (($acceptBase === '*' || $baseEqual)
+            && ($acceptSub === '*' || $subEqual || $acceptPlus === '*' || $plusEqual)
+            && count($intersection) === count($accept->getParameters())
+        ) {
+            $score = 100 * $baseEqual + 10 * $subEqual + $plusEqual + count($intersection);
+
+            return new Match($accept->getQuality() * $priority->getQuality(), $score, $index);
+        }
+
         return null;
+    }
+
+    /**
+     * Split a subpart into the subpart and "plus" part.
+     *
+     * For media-types of the form "application/vnd.example+json", matching
+     * should allow wildcards for either the portion before the "+" or
+     * after. This method splits the subpart to allow such matching.
+     */
+    protected function splitSubPart($subPart)
+    {
+        if (!strstr($subPart, '+')) {
+            return [$subPart, ''];
+        }
+
+        return explode('+', $subPart, 2);
     }
 }

--- a/tests/Negotiation/Tests/NegotiatorTest.php
+++ b/tests/Negotiation/Tests/NegotiatorTest.php
@@ -94,6 +94,9 @@ class NegotiatorTest extends TestCase
             array('image/jpeg, application/x-ms-application, image/gif, application/xaml+xml, image/pjpeg, application/x-ms-xbap, */*', array( 'text/html', 'application/xhtml+xml'), array('text/html', array())),
             # Quality of source factors
             array($rfcHeader, array('text/html;q=0.4', 'text/plain'), array('text/plain', array())),
+            # Wildcard "plus" parts (e.g., application/vnd.api+json)
+            array('application/vnd.api+json', array('application/json', 'application/*+json'), array('application/*+json', array())),
+            array($pearAcceptHeader, array('application/*+xml'), array('application/*+xml', array())),
         );
     }
 


### PR DESCRIPTION
A relatively common way to allow negotation to multiple serialization structures for a single media type is to use "+" notation within the mediatype:

- `application/vnd.book+json`: JSON serialization of `application/vnd.book` mediatype.
- `application/vnd.book+xml`: XML serialization of `application/vnd.book` mediatype.

In particular, this is useful for determining what _general_ serialization is used for an incoming request in order to select an appropriate deserializer.

With the current 2.X branch, I expected the following to work:

```php
use Negotiation\Negotiator;

$mediaType = (new Negotiator)->getBest($accept, [
    'application/json',
    'application/*+json',
    'application/xml',
    'application/*+xml',
]);
```

However, it failed on each of the cases listed above.

This patch provides additional negotiation routines within `Negotiation\Negotiator::match` in order to allow such negotiation to work as expected.