### PR TITLE
Do not compare + segments unless wildcards in either accept or priority

### DIFF
--- a/src/Negotiation/Negotiator.php
+++ b/src/Negotiation/Negotiator.php
@@ -50,8 +50,9 @@ class Negotiator extends AbstractNegotiator
         list($prioritySub, $priorityPlus) = $this->splitSubPart($prioritySub);
 
         // If no wildcards in either the subtype or + segment, do nothing.
-        if (! ($acceptBase === '*' || $baseEqual)
-            || ! ($acceptSub === '*' || $prioritySub === '*' || $acceptPlus === '*' || $priorityPlus === '*')) {
+        if (!($acceptBase === '*' || $baseEqual)
+            || !($acceptSub === '*' || $prioritySub === '*' || $acceptPlus === '*' || $priorityPlus === '*')
+        ) {
             return null;
         }
 

--- a/src/Negotiation/Negotiator.php
+++ b/src/Negotiation/Negotiator.php
@@ -49,11 +49,17 @@ class Negotiator extends AbstractNegotiator
         list($acceptSub, $acceptPlus) = $this->splitSubPart($acceptSub);
         list($prioritySub, $priorityPlus) = $this->splitSubPart($prioritySub);
 
+        // If no wildcards in either the subtype or + segment, do nothing.
+        if (! ($acceptBase === '*' || $baseEqual)
+            || ! ($acceptSub === '*' || $prioritySub === '*' || $acceptPlus === '*' || $priorityPlus === '*')) {
+            return null;
+        }
+
         $subEqual  = !strcasecmp($acceptSub, $prioritySub);
         $plusEqual = !strcasecmp($acceptPlus, $priorityPlus);
 
-        if (($acceptBase === '*' || $baseEqual)
-            && ($acceptSub === '*' || $subEqual || $acceptPlus === '*' || $plusEqual)
+        if (($acceptSub === '*' || $prioritySub === '*' || $subEqual)
+            && ($acceptPlus === '*' || $priorityPlus === '*' || $plusEqual)
             && count($intersection) === count($accept->getParameters())
         ) {
             $score = 100 * $baseEqual + 10 * $subEqual + $plusEqual + count($intersection);

--- a/tests/Negotiation/Tests/NegotiatorTest.php
+++ b/tests/Negotiation/Tests/NegotiatorTest.php
@@ -96,7 +96,11 @@ class NegotiatorTest extends TestCase
             array($rfcHeader, array('text/html;q=0.4', 'text/plain'), array('text/plain', array())),
             # Wildcard "plus" parts (e.g., application/vnd.api+json)
             array('application/vnd.api+json', array('application/json', 'application/*+json'), array('application/*+json', array())),
+            array('application/json;q=0.7, application/*+json;q=0.7', array('application/hal+json', 'application/problem+json'), array('application/hal+json', array())),
+            array('application/json;q=0.7, application/problem+*;q=0.7', array('application/hal+xml', 'application/problem+xml'), array('application/problem+xml', array())),
             array($pearAcceptHeader, array('application/*+xml'), array('application/*+xml', array())),
+            # @see https://github.com/willdurand/Negotiation/issues/93
+            array('application/hal+json', array('application/ld+json', 'application/hal+json', 'application/xml', 'text/xml', 'application/json', 'text/html'), array('application/hal+json', array())),
         );
     }
 


### PR DESCRIPTION
Fixes #93. If there are no wildcard segments in either the subtype or `+` segment of either the Accept header or priority, do not attempt to compare them.

Adds more tests for #92 as well, using `*` subtypes in both the Accept header and priorities, to validate that different combinations work as expected.