### PR TITLE
Updating 2.x branch to run on current php version on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ sudo: false
 language: php
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
+    - 7.1
+    - 7.2
+    - 7.3
+    - 7.4
     - hhvm
 
 matrix:
@@ -13,7 +15,6 @@ matrix:
         - php: hhvm
 
 before_script:
-    - composer self-update
     - composer install --prefer-dist --no-interaction
 
-script: phpunit --coverage-text
+script: ./vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5"
+        "phpunit/phpunit": "^5.0 || ^6.0 || ^7.0.15"
     }
 }

--- a/tests/Negotiation/Tests/CharsetNegotiatorTest.php
+++ b/tests/Negotiation/Tests/CharsetNegotiatorTest.php
@@ -43,7 +43,7 @@ class CharsetNegotiatorTest extends TestCase
     public function testGetBest($accept, $priorities, $expected)
     {
         if (is_null($expected))
-            $this->setExpectedException('Negotiation\Exception\InvalidArgument');
+            $this->expectException('Negotiation\Exception\InvalidArgument');
 
         $accept = $this->negotiator->getBest($accept, $priorities);
         if (null === $accept) {

--- a/tests/Negotiation/Tests/TestCase.php
+++ b/tests/Negotiation/Tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Negotiation\Tests;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     protected function call_private_method($class, $method, $object, $params)
     {


### PR DESCRIPTION
We're using 2.x version of this lib and I was curious if the tests would pass without deprecation notices and such in PHP 7.3 and 7.4 so I made some modifications to `composer.json`, `.travis.yml` and a couple of files in the `tests` directory in order to get the tests to pass against PHP 5.6 through 7.4.

No changes were made to any files in the `src`, just development related changes.

I'm not sure if you're accepting PRs against the 2.x branch, but since I took the time to do this I figured it might be helpful for you.

Thanks!