### PR TITLE
Add support for PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ sudo: false
 language: php
 
 php:
-    - 7.0
-    - 7.1
-    - 7.2
     - 7.3
+    - 7.4
+    - nightly
     - hhvm
 
 matrix:
@@ -13,7 +12,7 @@ matrix:
         - php: hhvm
 
 before_script:
-    - composer self-update
-    - composer install --prefer-dist --no-interaction
+    - composer self-update --2
+    - composer install --prefer-dist --no-interaction --ignore-platform-req=php
 
 script: vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,10 @@ php:
     - 7.3
     - 7.4
     - nightly
-    - hhvm
-
-matrix:
-    allow_failures:
-        - php: hhvm
 
 before_script:
     - composer self-update --2
+    # --ignore-platform-req is required here to get PHPUnit and all required dependencies to install on PHP 8
     - composer install --prefer-dist --no-interaction --ignore-platform-req=php
 
 script: vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 sudo: false
 language: php
 
-php:
-    - 7.3
-    - 7.4
-    - nightly
+matrix:
+    include:
+        - php: 7.1
+          env: SYMFONY_PHPUNIT_VERSION=7.5
+        - php: 7.2
+          env: SYMFONY_PHPUNIT_VERSION=8.5
+        - php: 7.3
+          env: SYMFONY_PHPUNIT_VERSION=9.3
+        - php: 7.4
+          env: SYMFONY_PHPUNIT_VERSION=9.3
+        - php: nightly
+          env: SYMFONY_PHPUNIT_VERSION=9.3
 
 before_script:
     - composer self-update --2
-    # --ignore-platform-req is required here to get PHPUnit and all required dependencies to install on PHP 8
-    - composer install --prefer-dist --no-interaction --ignore-platform-req=php
+    - composer install --prefer-dist --no-interaction
 
-script: vendor/bin/phpunit --coverage-text
+script: vendor/bin/simple-phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
             "dev-master": "3.0-dev"
         }
     },
-    "minimum-stability": "dev",
     "require-dev": {
         "symfony/phpunit-bridge": "^5.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3.0"
+        "php": ">=7.1.0"
     },
     "autoload": {
         "psr-4": { "Negotiation\\": "src/Negotiation" }
@@ -26,6 +26,6 @@
     },
     "minimum-stability": "dev",
     "require-dev": {
-        "phpunit/phpunit": "9.3.x-dev"
+        "symfony/phpunit-bridge": "^5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=7.3.0"
     },
     "autoload": {
         "psr-4": { "Negotiation\\": "src/Negotiation" }
@@ -24,7 +24,8 @@
             "dev-master": "3.0-dev"
         }
     },
+    "minimum-stability": "dev",
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "9.3.x-dev"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    backupGlobals="false"
     backupStaticAttributes="false"
     colors="true"
     convertErrorsToExceptions="true"
@@ -7,7 +8,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="tests/bootstrap.php"
     >
     <testsuites>
@@ -15,9 +15,9 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/Negotiation/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -43,9 +43,9 @@ abstract class AbstractNegotiator
             $acceptedPriorities[] = $this->acceptFactory($p);
         }
         $matches         = $this->findMatches($acceptedHeaders, $acceptedPriorities);
-        $specificMatches = array_reduce($matches, 'Negotiation\Matched::reduce', []);
+        $specificMatches = array_reduce($matches, 'Negotiation\AcceptMatch::reduce', []);
 
-        usort($specificMatches, 'Negotiation\Matched::compare');
+        usort($specificMatches, 'Negotiation\AcceptMatch::compare');
 
         $match = array_shift($specificMatches);
 
@@ -109,7 +109,7 @@ abstract class AbstractNegotiator
      * @param AcceptHeader $priority
      * @param integer      $index
      *
-     * @return Matched|null Headers matched
+     * @return AcceptMatch|null Headers matched
      */
     protected function match(AcceptHeader $header, AcceptHeader $priority, $index)
     {
@@ -121,7 +121,7 @@ abstract class AbstractNegotiator
         if ($equal || $ac === '*') {
             $score = 1 * $equal;
 
-            return new Matched($header->getQuality() * $priority->getQuality(), $score, $index);
+            return new AcceptMatch($header->getQuality() * $priority->getQuality(), $score, $index);
         }
 
         return null;
@@ -147,7 +147,7 @@ abstract class AbstractNegotiator
      * @param AcceptHeader[] $headerParts
      * @param Priority[]     $priorities  Configured priorities
      *
-     * @return Matched[] Headers matched
+     * @return AcceptMatch[] Headers matched
      */
     private function findMatches(array $headerParts, array $priorities)
     {

--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -43,9 +43,9 @@ abstract class AbstractNegotiator
             $acceptedPriorities[] = $this->acceptFactory($p);
         }
         $matches         = $this->findMatches($acceptedHeaders, $acceptedPriorities);
-        $specificMatches = array_reduce($matches, 'Negotiation\Match::reduce', []);
+        $specificMatches = array_reduce($matches, 'Negotiation\Matched::reduce', []);
 
-        usort($specificMatches, 'Negotiation\Match::compare');
+        usort($specificMatches, 'Negotiation\Matched::compare');
 
         $match = array_shift($specificMatches);
 
@@ -83,7 +83,7 @@ abstract class AbstractNegotiator
             $qB = $b[0];
 
             if ($qA == $qB) {
-                return $a[1] > $b[1];
+                return $a[1] <=> $b[1];
             }
 
             return ($qA > $qB) ? -1 : 1;
@@ -109,7 +109,7 @@ abstract class AbstractNegotiator
      * @param AcceptHeader $priority
      * @param integer      $index
      *
-     * @return Match|null Headers matched
+     * @return Matched|null Headers matched
      */
     protected function match(AcceptHeader $header, AcceptHeader $priority, $index)
     {
@@ -121,7 +121,7 @@ abstract class AbstractNegotiator
         if ($equal || $ac === '*') {
             $score = 1 * $equal;
 
-            return new Match($header->getQuality() * $priority->getQuality(), $score, $index);
+            return new Matched($header->getQuality() * $priority->getQuality(), $score, $index);
         }
 
         return null;
@@ -147,7 +147,7 @@ abstract class AbstractNegotiator
      * @param AcceptHeader[] $headerParts
      * @param Priority[]     $priorities  Configured priorities
      *
-     * @return Match[] Headers matched
+     * @return Matched[] Headers matched
      */
     private function findMatches(array $headerParts, array $priorities)
     {

--- a/src/Negotiation/AcceptMatch.php
+++ b/src/Negotiation/AcceptMatch.php
@@ -2,7 +2,7 @@
 
 namespace Negotiation;
 
-final class Matched
+final class AcceptMatch
 {
     /**
      * @var float
@@ -27,12 +27,12 @@ final class Matched
     }
 
     /**
-     * @param Matched $a
-     * @param Matched $b
+     * @param AcceptMatch $a
+     * @param AcceptMatch $b
      *
      * @return int
      */
-    public static function compare(Matched $a, Matched $b)
+    public static function compare(AcceptMatch $a, AcceptMatch $b)
     {
         if ($a->quality !== $b->quality) {
             return $a->quality > $b->quality ? -1 : 1;
@@ -47,11 +47,11 @@ final class Matched
 
     /**
      * @param array   $carry reduced array
-     * @param Matched $match match to be reduced
+     * @param AcceptMatch $match match to be reduced
      *
-     * @return Matched[]
+     * @return AcceptMatch[]
      */
-    public static function reduce(array $carry, Matched $match)
+    public static function reduce(array $carry, AcceptMatch $match)
     {
         if (!isset($carry[$match->index]) || $carry[$match->index]->score < $match->score) {
             $carry[$match->index] = $match;

--- a/src/Negotiation/LanguageNegotiator.php
+++ b/src/Negotiation/LanguageNegotiator.php
@@ -33,7 +33,7 @@ class LanguageNegotiator extends AbstractNegotiator
         if (($ab == '*' || $baseEqual) && ($as === null || $subEqual)) {
             $score = 10 * $baseEqual + $subEqual;
 
-            return new Matched($acceptLanguage->getQuality() * $priority->getQuality(), $score, $index);
+            return new AcceptMatch($acceptLanguage->getQuality() * $priority->getQuality(), $score, $index);
         }
 
         return null;

--- a/src/Negotiation/LanguageNegotiator.php
+++ b/src/Negotiation/LanguageNegotiator.php
@@ -33,7 +33,7 @@ class LanguageNegotiator extends AbstractNegotiator
         if (($ab == '*' || $baseEqual) && ($as === null || $subEqual)) {
             $score = 10 * $baseEqual + $subEqual;
 
-            return new Match($acceptLanguage->getQuality() * $priority->getQuality(), $score, $index);
+            return new Matched($acceptLanguage->getQuality() * $priority->getQuality(), $score, $index);
         }
 
         return null;

--- a/src/Negotiation/Matched.php
+++ b/src/Negotiation/Matched.php
@@ -2,7 +2,7 @@
 
 namespace Negotiation;
 
-final class Match
+final class Matched
 {
     /**
      * @var float
@@ -27,12 +27,12 @@ final class Match
     }
 
     /**
-     * @param Match $a
-     * @param Match $b
+     * @param Matched $a
+     * @param Matched $b
      *
      * @return int
      */
-    public static function compare(Match $a, Match $b)
+    public static function compare(Matched $a, Matched $b)
     {
         if ($a->quality !== $b->quality) {
             return $a->quality > $b->quality ? -1 : 1;
@@ -46,12 +46,12 @@ final class Match
     }
 
     /**
-     * @param array $carry reduced array
-     * @param Match $match match to be reduced
+     * @param array   $carry reduced array
+     * @param Matched $match match to be reduced
      *
-     * @return Match[]
+     * @return Matched[]
      */
-    public static function reduce(array $carry, Match $match)
+    public static function reduce(array $carry, Matched $match)
     {
         if (!isset($carry[$match->index]) || $carry[$match->index]->score < $match->score) {
             $carry[$match->index] = $match;

--- a/src/Negotiation/Negotiator.php
+++ b/src/Negotiation/Negotiator.php
@@ -38,7 +38,7 @@ class Negotiator extends AbstractNegotiator
         ) {
             $score = 100 * $baseEqual + 10 * $subEqual + count($intersection);
 
-            return new Matched($accept->getQuality() * $priority->getQuality(), $score, $index);
+            return new AcceptMatch($accept->getQuality() * $priority->getQuality(), $score, $index);
         }
 
         if (!strstr($acceptSub, '+') || !strstr($prioritySub, '+')) {
@@ -65,7 +65,7 @@ class Negotiator extends AbstractNegotiator
         ) {
             $score = 100 * $baseEqual + 10 * $subEqual + $plusEqual + count($intersection);
 
-            return new Matched($accept->getQuality() * $priority->getQuality(), $score, $index);
+            return new AcceptMatch($accept->getQuality() * $priority->getQuality(), $score, $index);
         }
 
         return null;

--- a/src/Negotiation/Negotiator.php
+++ b/src/Negotiation/Negotiator.php
@@ -38,7 +38,7 @@ class Negotiator extends AbstractNegotiator
         ) {
             $score = 100 * $baseEqual + 10 * $subEqual + count($intersection);
 
-            return new Match($accept->getQuality() * $priority->getQuality(), $score, $index);
+            return new Matched($accept->getQuality() * $priority->getQuality(), $score, $index);
         }
 
         if (!strstr($acceptSub, '+') || !strstr($prioritySub, '+')) {
@@ -65,7 +65,7 @@ class Negotiator extends AbstractNegotiator
         ) {
             $score = 100 * $baseEqual + 10 * $subEqual + $plusEqual + count($intersection);
 
-            return new Match($accept->getQuality() * $priority->getQuality(), $score, $index);
+            return new Matched($accept->getQuality() * $priority->getQuality(), $score, $index);
         }
 
         return null;

--- a/tests/Negotiation/Tests/CharsetNegotiatorTest.php
+++ b/tests/Negotiation/Tests/CharsetNegotiatorTest.php
@@ -12,7 +12,7 @@ class CharsetNegotiatorTest extends TestCase
      */
     private $negotiator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->negotiator = new CharsetNegotiator();
     }

--- a/tests/Negotiation/Tests/EncodingNegotiatorTest.php
+++ b/tests/Negotiation/Tests/EncodingNegotiatorTest.php
@@ -12,7 +12,7 @@ class EncodingNegotiatorTest extends TestCase
      */
     private $negotiator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->negotiator = new EncodingNegotiator();
     }

--- a/tests/Negotiation/Tests/LanguageNegotiatorTest.php
+++ b/tests/Negotiation/Tests/LanguageNegotiatorTest.php
@@ -13,7 +13,7 @@ class LanguageNegotiatorTest extends TestCase
      */
     private $negotiator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->negotiator = new LanguageNegotiator();
     }

--- a/tests/Negotiation/Tests/MatchTest.php
+++ b/tests/Negotiation/Tests/MatchTest.php
@@ -2,7 +2,7 @@
 
 namespace Negotiation\Tests;
 
-use Negotiation\Match;
+use Negotiation\Matched;
 
 class MatchTest extends TestCase
 {
@@ -11,17 +11,17 @@ class MatchTest extends TestCase
      */
     public function testCompare($match1, $match2, $expected)
     {
-        $this->assertEquals($expected, Match::compare($match1, $match2));
+        $this->assertEquals($expected, Matched::compare($match1, $match2));
     }
 
     public static function dataProviderForTestCompare()
     {
         return array(
-            array(new Match(1.0, 110, 1), new Match(1.0, 111, 1),    0),
-            array(new Match(0.1, 10,  1), new Match(0.1,  10, 2),   -1),
-            array(new Match(0.5, 110, 5), new Match(0.5,  11, 4),    1),
-            array(new Match(0.4, 110, 1), new Match(0.6, 111, 3),    1),
-            array(new Match(0.6, 110, 1), new Match(0.4, 111, 3),   -1),
+            array(new Matched(1.0, 110, 1), new Matched(1.0, 111, 1),    0),
+            array(new Matched(0.1, 10,  1), new Matched(0.1,  10, 2),   -1),
+            array(new Matched(0.5, 110, 5), new Matched(0.5,  11, 4),    1),
+            array(new Matched(0.4, 110, 1), new Matched(0.6, 111, 3),    1),
+            array(new Matched(0.6, 110, 1), new Matched(0.4, 111, 3),   -1),
         );
     }
 
@@ -30,26 +30,26 @@ class MatchTest extends TestCase
      */
     public function testReduce($carry, $match, $expected)
     {
-        $this->assertEquals($expected, Match::reduce($carry, $match));
+        $this->assertEquals($expected, Matched::reduce($carry, $match));
     }
 
     public static function dataProviderForTestReduce()
     {
         return array(
             array(
-                array(1 => new Match(1.0, 10, 1)),
-                new Match(0.5, 111, 1),
-                array(1 => new Match(0.5, 111, 1)),
+                array(1 => new Matched(1.0, 10, 1)),
+                new Matched(0.5, 111, 1),
+                array(1 => new Matched(0.5, 111, 1)),
             ),
             array(
-                array(1 => new Match(1.0, 110, 1)),
-                new Match(0.5, 11, 1),
-                array(1 => new Match(1.0, 110, 1)),
+                array(1 => new Matched(1.0, 110, 1)),
+                new Matched(0.5, 11, 1),
+                array(1 => new Matched(1.0, 110, 1)),
             ),
             array(
-                array(0 => new Match(1.0, 10, 1)),
-                new Match(0.5, 111, 1),
-                array(0 => new Match(1.0, 10, 1), 1 => new Match(0.5, 111, 1)),
+                array(0 => new Matched(1.0, 10, 1)),
+                new Matched(0.5, 111, 1),
+                array(0 => new Matched(1.0, 10, 1), 1 => new Matched(0.5, 111, 1)),
             ),
         );
     }

--- a/tests/Negotiation/Tests/MatchTest.php
+++ b/tests/Negotiation/Tests/MatchTest.php
@@ -2,7 +2,7 @@
 
 namespace Negotiation\Tests;
 
-use Negotiation\Matched;
+use Negotiation\AcceptMatch;
 
 class MatchTest extends TestCase
 {
@@ -11,17 +11,17 @@ class MatchTest extends TestCase
      */
     public function testCompare($match1, $match2, $expected)
     {
-        $this->assertEquals($expected, Matched::compare($match1, $match2));
+        $this->assertEquals($expected, AcceptMatch::compare($match1, $match2));
     }
 
     public static function dataProviderForTestCompare()
     {
         return array(
-            array(new Matched(1.0, 110, 1), new Matched(1.0, 111, 1),    0),
-            array(new Matched(0.1, 10,  1), new Matched(0.1,  10, 2),   -1),
-            array(new Matched(0.5, 110, 5), new Matched(0.5,  11, 4),    1),
-            array(new Matched(0.4, 110, 1), new Matched(0.6, 111, 3),    1),
-            array(new Matched(0.6, 110, 1), new Matched(0.4, 111, 3),   -1),
+            array(new AcceptMatch(1.0, 110, 1), new AcceptMatch(1.0, 111, 1),    0),
+            array(new AcceptMatch(0.1, 10,  1), new AcceptMatch(0.1,  10, 2),   -1),
+            array(new AcceptMatch(0.5, 110, 5), new AcceptMatch(0.5,  11, 4),    1),
+            array(new AcceptMatch(0.4, 110, 1), new AcceptMatch(0.6, 111, 3),    1),
+            array(new AcceptMatch(0.6, 110, 1), new AcceptMatch(0.4, 111, 3),   -1),
         );
     }
 
@@ -30,26 +30,26 @@ class MatchTest extends TestCase
      */
     public function testReduce($carry, $match, $expected)
     {
-        $this->assertEquals($expected, Matched::reduce($carry, $match));
+        $this->assertEquals($expected, AcceptMatch::reduce($carry, $match));
     }
 
     public static function dataProviderForTestReduce()
     {
         return array(
             array(
-                array(1 => new Matched(1.0, 10, 1)),
-                new Matched(0.5, 111, 1),
-                array(1 => new Matched(0.5, 111, 1)),
+                array(1 => new AcceptMatch(1.0, 10, 1)),
+                new AcceptMatch(0.5, 111, 1),
+                array(1 => new AcceptMatch(0.5, 111, 1)),
             ),
             array(
-                array(1 => new Matched(1.0, 110, 1)),
-                new Matched(0.5, 11, 1),
-                array(1 => new Matched(1.0, 110, 1)),
+                array(1 => new AcceptMatch(1.0, 110, 1)),
+                new AcceptMatch(0.5, 11, 1),
+                array(1 => new AcceptMatch(1.0, 110, 1)),
             ),
             array(
-                array(0 => new Matched(1.0, 10, 1)),
-                new Matched(0.5, 111, 1),
-                array(0 => new Matched(1.0, 10, 1), 1 => new Matched(0.5, 111, 1)),
+                array(0 => new AcceptMatch(1.0, 10, 1)),
+                new AcceptMatch(0.5, 111, 1),
+                array(0 => new AcceptMatch(1.0, 10, 1), 1 => new AcceptMatch(0.5, 111, 1)),
             ),
         );
     }

--- a/tests/Negotiation/Tests/NegotiatorTest.php
+++ b/tests/Negotiation/Tests/NegotiatorTest.php
@@ -6,7 +6,7 @@ use Negotiation\Exception\InvalidArgument;
 use Negotiation\Exception\InvalidMediaType;
 use Negotiation\Negotiator;
 use Negotiation\Accept;
-use Negotiation\Matched;
+use Negotiation\AcceptMatch;
 
 class NegotiatorTest extends TestCase
 {
@@ -212,40 +212,40 @@ class NegotiatorTest extends TestCase
                 array(new Accept('text/html; charset=UTF-8'), new Accept('image/png; foo=bar; q=0.7'), new Accept('*/*; foo=bar; q=0.4')),
                 array(new Accept('text/html; charset=UTF-8'), new Accept('image/png; foo=bar'), new Accept('application/pdf')),
                 array(
-                    new Matched(1.0, 111, 0),
-                    new Matched(0.7, 111, 1),
-                    new Matched(0.4, 1,   1),
+                    new AcceptMatch(1.0, 111, 0),
+                    new AcceptMatch(0.7, 111, 1),
+                    new AcceptMatch(0.4, 1,   1),
                 )
             ),
             array(
                 array(new Accept('text/html'), new Accept('image/*; q=0.7')),
                 array(new Accept('text/html; asfd=qwer'), new Accept('image/png'), new Accept('application/pdf')),
                 array(
-                    new Matched(1.0, 110, 0),
-                    new Matched(0.7, 100, 1),
+                    new AcceptMatch(1.0, 110, 0),
+                    new AcceptMatch(0.7, 100, 1),
                 )
             ),
             array( # https://tools.ietf.org/html/rfc7231#section-5.3.2
                 array(new Accept('text/*; q=0.3'), new Accept('text/html; q=0.7'), new Accept('text/html; level=1'), new Accept('text/html; level=2; q=0.4'), new Accept('*/*; q=0.5')),
                 array(new Accept('text/html; level=1'), new Accept('text/html'), new Accept('text/plain'), new Accept('image/jpeg'), new Accept('text/html; level=2'), new Accept('text/html; level=3')),
                 array(
-                    new Matched(0.3,    100,    0),
-                    new Matched(0.7,    110,    0),
-                    new Matched(1.0,    111,    0),
-                    new Matched(0.5,      0,    0),
-                    new Matched(0.3,    100,    1),
-                    new Matched(0.7,    110,    1),
-                    new Matched(0.5,      0,    1),
-                    new Matched(0.3,    100,    2),
-                    new Matched(0.5,      0,    2),
-                    new Matched(0.5,      0,    3),
-                    new Matched(0.3,    100,    4),
-                    new Matched(0.7,    110,    4),
-                    new Matched(0.4,    111,    4),
-                    new Matched(0.5,      0,    4),
-                    new Matched(0.3,    100,    5),
-                    new Matched(0.7,    110,    5),
-                    new Matched(0.5,      0,    5),
+                    new AcceptMatch(0.3,    100,    0),
+                    new AcceptMatch(0.7,    110,    0),
+                    new AcceptMatch(1.0,    111,    0),
+                    new AcceptMatch(0.5,      0,    0),
+                    new AcceptMatch(0.3,    100,    1),
+                    new AcceptMatch(0.7,    110,    1),
+                    new AcceptMatch(0.5,      0,    1),
+                    new AcceptMatch(0.3,    100,    2),
+                    new AcceptMatch(0.5,      0,    2),
+                    new AcceptMatch(0.5,      0,    3),
+                    new AcceptMatch(0.3,    100,    4),
+                    new AcceptMatch(0.7,    110,    4),
+                    new AcceptMatch(0.4,    111,    4),
+                    new AcceptMatch(0.5,      0,    4),
+                    new AcceptMatch(0.3,    100,    5),
+                    new AcceptMatch(0.7,    110,    5),
+                    new AcceptMatch(0.5,      0,    5),
                 )
             )
         );

--- a/tests/Negotiation/Tests/NegotiatorTest.php
+++ b/tests/Negotiation/Tests/NegotiatorTest.php
@@ -6,7 +6,7 @@ use Negotiation\Exception\InvalidArgument;
 use Negotiation\Exception\InvalidMediaType;
 use Negotiation\Negotiator;
 use Negotiation\Accept;
-use Negotiation\Match;
+use Negotiation\Matched;
 
 class NegotiatorTest extends TestCase
 {
@@ -16,7 +16,7 @@ class NegotiatorTest extends TestCase
      */
     private $negotiator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->negotiator = new Negotiator();
     }
@@ -160,11 +160,9 @@ class NegotiatorTest extends TestCase
         $this->assertEquals('text/plain', $accept->getType());
     }
 
-   /**
-    * @expectedException Negotiation\Exception\InvalidMediaType
-    */
     public function testGetBestInvalidMediaType()
     {
+        $this->expectException(\Negotiation\Exception\InvalidMediaType::class);
         $header = 'sdlfkj20ff; wdf';
         $priorities = array('foo/qwer');
 
@@ -214,40 +212,40 @@ class NegotiatorTest extends TestCase
                 array(new Accept('text/html; charset=UTF-8'), new Accept('image/png; foo=bar; q=0.7'), new Accept('*/*; foo=bar; q=0.4')),
                 array(new Accept('text/html; charset=UTF-8'), new Accept('image/png; foo=bar'), new Accept('application/pdf')),
                 array(
-                    new Match(1.0, 111, 0),
-                    new Match(0.7, 111, 1),
-                    new Match(0.4, 1,   1),
+                    new Matched(1.0, 111, 0),
+                    new Matched(0.7, 111, 1),
+                    new Matched(0.4, 1,   1),
                 )
             ),
             array(
                 array(new Accept('text/html'), new Accept('image/*; q=0.7')),
                 array(new Accept('text/html; asfd=qwer'), new Accept('image/png'), new Accept('application/pdf')),
                 array(
-                    new Match(1.0, 110, 0),
-                    new Match(0.7, 100, 1),
+                    new Matched(1.0, 110, 0),
+                    new Matched(0.7, 100, 1),
                 )
             ),
             array( # https://tools.ietf.org/html/rfc7231#section-5.3.2
                 array(new Accept('text/*; q=0.3'), new Accept('text/html; q=0.7'), new Accept('text/html; level=1'), new Accept('text/html; level=2; q=0.4'), new Accept('*/*; q=0.5')),
                 array(new Accept('text/html; level=1'), new Accept('text/html'), new Accept('text/plain'), new Accept('image/jpeg'), new Accept('text/html; level=2'), new Accept('text/html; level=3')),
                 array(
-                    new Match(0.3,    100,    0),
-                    new Match(0.7,    110,    0),
-                    new Match(1.0,    111,    0),
-                    new Match(0.5,      0,    0),
-                    new Match(0.3,    100,    1),
-                    new Match(0.7,    110,    1),
-                    new Match(0.5,      0,    1),
-                    new Match(0.3,    100,    2),
-                    new Match(0.5,      0,    2),
-                    new Match(0.5,      0,    3),
-                    new Match(0.3,    100,    4),
-                    new Match(0.7,    110,    4),
-                    new Match(0.4,    111,    4),
-                    new Match(0.5,      0,    4),
-                    new Match(0.3,    100,    5),
-                    new Match(0.7,    110,    5),
-                    new Match(0.5,      0,    5),
+                    new Matched(0.3,    100,    0),
+                    new Matched(0.7,    110,    0),
+                    new Matched(1.0,    111,    0),
+                    new Matched(0.5,      0,    0),
+                    new Matched(0.3,    100,    1),
+                    new Matched(0.7,    110,    1),
+                    new Matched(0.5,      0,    1),
+                    new Matched(0.3,    100,    2),
+                    new Matched(0.5,      0,    2),
+                    new Matched(0.5,      0,    3),
+                    new Matched(0.3,    100,    4),
+                    new Matched(0.7,    110,    4),
+                    new Matched(0.4,    111,    4),
+                    new Matched(0.5,      0,    4),
+                    new Matched(0.3,    100,    5),
+                    new Matched(0.7,    110,    5),
+                    new Matched(0.5,      0,    5),
                 )
             )
         );


### PR DESCRIPTION
The biggest change to support PHP 8 is the `Match` class which fails due to the new [match expression](https://wiki.php.net/rfc/match_expression_v2) (`match` is now a reserved keyword).

This PR also adds PHP nightly on Travis in order to run the unit tests on PHP 8. This requires an upgrade on PHPUnit to 9.3-dev which is the only version to support PHP 8. But this means PHP 7.0 - 7.2 support needs to be dropped (7.2 is in security-fix for the next 3 months only).

An alternative option to keep support for PHP < 7.3 is to install different PHPUnit versions in Travis for each build. If you want to go that route then I'll update the PR accordingly.