### PR TITLE
Fix invalid PHPDocs return comment

### DIFF
--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -55,7 +55,7 @@ abstract class AbstractNegotiator
     /**
      * @param string $header A string containing an `Accept|Accept-*` header.
      *
-     * @return [AcceptHeader] An ordered list of accept header elements
+     * @return AcceptHeader[] An ordered list of accept header elements
      */
     public function getOrderedElements($header)
     {


### PR DESCRIPTION
As per Psalm error:

```
ERROR: InvalidDocblock - vendor/willdurand/negotiation/src/Negotiation/AbstractNegotiator.php:60:5 - Unexpected token [ in docblock for Negotiation\AbstractNegotiator::getOrderedElements (see https://psalm.dev/008)
    /**
     * @param string $header A string containing an `Accept|Accept-*` header.
     *
     * @return [AcceptHeader] An ordered list of accept header elements
     */
    public function getOrderedElements($header)
```