### PR TITLE
Improvements to Type Hinting and Object Model

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,4 +31,30 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/simple-phpunit --coverage-text"
+        run: "vendor/bin/phpunit --coverage-text"
+
+  phpstan:
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "7.4"
+          - "8.0"
+          - "8.1"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Install PHP ${{ matrix.php-version }}"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          coverage: "pcov"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v1"
+
+      - name: "Run PHPStan"
+        run: "vendor/bin/phpstan analyse src --level 5"

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         }
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.0"
+        "symfony/phpunit-bridge": "^5.0",
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan": "^1.4"
     }
 }

--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -130,7 +130,7 @@ abstract class AbstractNegotiator
     /**
      * @param string $header A string that contains an `Accept*` header.
      *
-     * @return AcceptHeader[]
+     * @return string[]
      */
     private function parseHeader($header)
     {

--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -105,13 +105,13 @@ abstract class AbstractNegotiator
     abstract protected function acceptFactory($header);
 
     /**
-     * @param AcceptHeader $header
-     * @param AcceptHeader $priority
+     * @param BaseAccept $header
+     * @param BaseAccept $priority
      * @param integer      $index
      *
      * @return AcceptMatch|null Headers matched
      */
-    protected function match(AcceptHeader $header, AcceptHeader $priority, $index)
+    protected function match(BaseAccept $header, BaseAccept $priority, $index)
     {
         $ac = $header->getType();
         $pc = $priority->getType();

--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -144,8 +144,8 @@ abstract class AbstractNegotiator
     }
 
     /**
-     * @param AcceptHeader[] $headerParts
-     * @param AcceptHeader[]     $priorities  Configured priorities
+     * @param BaseAccept[] $headerParts
+     * @param BaseAccept[]     $priorities  Configured priorities
      *
      * @return AcceptMatch[] Headers matched
      */

--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -100,7 +100,7 @@ abstract class AbstractNegotiator
     /**
      * @param string $header accept header part or server priority
      *
-     * @return AcceptHeader Parsed header object
+     * @return BaseAccept Parsed header object
      */
     abstract protected function acceptFactory($header);
 

--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -145,7 +145,7 @@ abstract class AbstractNegotiator
 
     /**
      * @param AcceptHeader[] $headerParts
-     * @param Priority[]     $priorities  Configured priorities
+     * @param AcceptHeader[]     $priorities  Configured priorities
      *
      * @return AcceptMatch[] Headers matched
      */

--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -11,7 +11,7 @@ abstract class AbstractNegotiator
      * @param string $header     A string containing an `Accept|Accept-*` header.
      * @param array  $priorities A set of server priorities.
      *
-     * @return AcceptHeader|null best matching type
+     * @return BaseAccept|null best matching type
      */
     public function getBest($header, array $priorities, $strict = false)
     {

--- a/src/Negotiation/Accept.php
+++ b/src/Negotiation/Accept.php
@@ -4,7 +4,7 @@ namespace Negotiation;
 
 use Negotiation\Exception\InvalidMediaType;
 
-final class Accept extends BaseAccept implements AcceptHeader
+final class Accept extends BaseAccept
 {
     private $basePart;
 

--- a/src/Negotiation/AcceptCharset.php
+++ b/src/Negotiation/AcceptCharset.php
@@ -2,6 +2,6 @@
 
 namespace Negotiation;
 
-final class AcceptCharset extends BaseAccept implements AcceptHeader
+final class AcceptCharset extends BaseAccept
 {
 }

--- a/src/Negotiation/AcceptEncoding.php
+++ b/src/Negotiation/AcceptEncoding.php
@@ -2,6 +2,6 @@
 
 namespace Negotiation;
 
-final class AcceptEncoding extends BaseAccept implements AcceptHeader
+final class AcceptEncoding extends BaseAccept
 {
 }

--- a/src/Negotiation/AcceptLanguage.php
+++ b/src/Negotiation/AcceptLanguage.php
@@ -32,7 +32,7 @@ final class AcceptLanguage extends BaseAccept
     }
 
     /**
-     * @return string
+     * @return null|string
      */
     public function getSubPart()
     {

--- a/src/Negotiation/AcceptLanguage.php
+++ b/src/Negotiation/AcceptLanguage.php
@@ -4,7 +4,7 @@ namespace Negotiation;
 
 use Negotiation\Exception\InvalidLanguage;
 
-final class AcceptLanguage extends BaseAccept implements AcceptHeader
+final class AcceptLanguage extends BaseAccept
 {
     private $language;
     private $script;

--- a/src/Negotiation/AcceptLanguage.php
+++ b/src/Negotiation/AcceptLanguage.php
@@ -46,4 +46,12 @@ final class AcceptLanguage extends BaseAccept
     {
         return $this->language;
     }
+
+    /**
+     * @return null|string
+     */
+    public function getScript()
+    {
+        return $this->script;
+    }
 }

--- a/src/Negotiation/BaseAccept.php
+++ b/src/Negotiation/BaseAccept.php
@@ -140,14 +140,13 @@ abstract class BaseAccept implements AcceptHeader
     }
 
     /**
-     * @param string $parameters
+     * @param array<string, string> $parameters
      *
      * @return string
      */
     private function buildParametersString($parameters)
     {
         $parts = [];
-
         ksort($parameters);
         foreach ($parameters as $key => $val) {
             $parts[] = sprintf('%s=%s', $key, $val);

--- a/src/Negotiation/BaseAccept.php
+++ b/src/Negotiation/BaseAccept.php
@@ -2,7 +2,7 @@
 
 namespace Negotiation;
 
-abstract class BaseAccept
+abstract class BaseAccept implements AcceptHeader
 {
     /**
      * @var float

--- a/src/Negotiation/LanguageNegotiator.php
+++ b/src/Negotiation/LanguageNegotiator.php
@@ -15,7 +15,7 @@ class LanguageNegotiator extends AbstractNegotiator
     /**
      * {@inheritdoc}
      */
-    protected function match(AcceptHeader $acceptLanguage, AcceptHeader $priority, $index)
+    protected function match(BaseAccept $acceptLanguage, BaseAccept $priority, $index)
     {
         if (!$acceptLanguage instanceof AcceptLanguage || !$priority instanceof AcceptLanguage) {
             return null;

--- a/tests/Negotiation/Tests/AcceptLanguageTest.php
+++ b/tests/Negotiation/Tests/AcceptLanguageTest.php
@@ -42,6 +42,12 @@ class AcceptLanguageTest extends TestCase
 
     }
 
+    public function testGetScript()
+    {
+        $accept = new AcceptLanguage("zh-Hans-CN;q=0.3");
+        $this->assertSame("hans", $accept->getScript());
+    }
+
     public static function dataProviderForGetValue()
     {
         return array(


### PR DESCRIPTION
This PR fixes #89 - IDEs will not complain about the use of type hints or object inheritance any more.

I have used PHPStan set to level 5 checks to expose any ambiguous/incorrect uses of type hinting. My IDE is happy now!