### PR TITLE
Fix to allow for use with PHP8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
 
     steps:
       - uses: actions/checkout@v2

--- a/src/Negotiation/AbstractNegotiator.php
+++ b/src/Negotiation/AbstractNegotiator.php
@@ -111,7 +111,7 @@ abstract class AbstractNegotiator
      *
      * @return AcceptMatch|null Headers matched
      */
-    protected function match(AcceptHeader $header, AcceptHeader $priority, $index)
+    protected function matchHeader(AcceptHeader $header, AcceptHeader $priority, $index)
     {
         $ac = $header->getType();
         $pc = $priority->getType();
@@ -154,7 +154,7 @@ abstract class AbstractNegotiator
         $matches = [];
         foreach ($priorities as $index => $p) {
             foreach ($headerParts as $h) {
-                if (null !== $match = $this->match($h, $p, $index)) {
+                if (null !== $match = $this->matchHeader($h, $p, $index)) {
                     $matches[] = $match;
                 }
             }

--- a/src/Negotiation/LanguageNegotiator.php
+++ b/src/Negotiation/LanguageNegotiator.php
@@ -15,7 +15,7 @@ class LanguageNegotiator extends AbstractNegotiator
     /**
      * {@inheritdoc}
      */
-    protected function match(AcceptHeader $acceptLanguage, AcceptHeader $priority, $index)
+    protected function matchHeader(AcceptHeader $acceptLanguage, AcceptHeader $priority, $index)
     {
         if (!$acceptLanguage instanceof AcceptLanguage || !$priority instanceof AcceptLanguage) {
             return null;

--- a/src/Negotiation/Negotiator.php
+++ b/src/Negotiation/Negotiator.php
@@ -15,7 +15,7 @@ class Negotiator extends AbstractNegotiator
     /**
      * {@inheritdoc}
      */
-    protected function match(AcceptHeader $accept, AcceptHeader $priority, $index)
+    protected function matchHeader(AcceptHeader $accept, AcceptHeader $priority, $index)
     {
         if (!$accept instanceof Accept || !$priority instanceof Accept) {
             return null;


### PR DESCRIPTION
Previous code had a method named "match" which is now a restricted name.