### PR TITLE
Add .gitattributes for `export-ignore`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.gitattributes export-ignore
+/.github/ export-ignore
+/.gitignore export-ignore
+/CONTRIBUTING.md export-ignore
+/phpunit.xml.dist export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
This avoids downloading files that are not needed at runtime, thus reducing traffic and the size of the `vendor/` directory.